### PR TITLE
Add README note about raw socket permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ Outputs:
 {count: 3, success: 3, fail: 0, average_response: 29.333333333333332}
 ```
 
+## Notes On Permissions
+
+This implementation requires raw sockets. On Linux this means that you either need to run as root or to set the correct capability on the executable. You can do this with:
+```
+setcap cap_net_raw=ep executable-name
+```
+If you lack the capability the code will throw an `Errno` exception with `#e == LibC::EPERM`
+
 ## Contributing
 
 Contributions are welcome. Please fork the repository, commit changes on a branch, and then open a pull request.


### PR DESCRIPTION
Feel free to reject this if you'd rather document elsewhere.

In fact, reject it anyway, I just noticed I made a typo. `#e` should be `#errno`.