### PR TITLE
fix Time.now deprecation and checksum int overflow

### DIFF
--- a/src/icmp.cr
+++ b/src/icmp.cr
@@ -1,5 +1,4 @@
 require "socket"
-require "time"
 
 require "./icmp/**"
 

--- a/src/icmp.cr
+++ b/src/icmp.cr
@@ -1,4 +1,5 @@
 require "socket"
+require "time"
 
 require "./icmp/**"
 
@@ -53,7 +54,7 @@ module ICMP
       count.times do
         request = EchoRequest.new(@requests.size.to_u16, sender_id)
         @requests.push request
-        request.sent_at Time.now
+        request.sent_at Time.local
         send request
 
         @socket.read_timeout = timeout
@@ -104,7 +105,7 @@ module ICMP
     private def receive_response : EchoRequest | Nil
       buffer = Bytes.new(PACKET_LENGTH_8 + IP_HEADER_SIZE_8)
       count, address = socket.receive buffer
-      timestamp = Time.now
+      timestamp = Time.local
 
       length = buffer.size
       icmp = buffer[IP_HEADER_SIZE_8, length-IP_HEADER_SIZE_8]

--- a/src/icmp/packet.cr
+++ b/src/icmp/packet.cr
@@ -33,7 +33,7 @@ module ICMP
       checksum = checksum ^ 0xffff_ffff_u32
 
       # truncate the number and map back to 16 bits
-      checksum.to_u16
+      (checksum & 0xffff).to_u16
     end
 
     def check_checksum


### PR DESCRIPTION
- Time.now has been deprecated in recent Crystal versions, so you get errors like
```
$ crystal spec
Showing last frame. Use --error-trace for full trace.

In src/icmp.cr:56:30

 56 | request.sent_at Time.now
                           ^--
Error: undefined method 'now' for Time.class
```
- fixed possible arithmetic overflow in checksum calculation; maybe because newer Crystal compiler is more picky on this